### PR TITLE
Fixes #4 - allow process.env to be populated before the ember app loads

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,21 +2,13 @@
 module.exports = {
   name: 'ember-cli-dotenv',
   config: function(){
-    if (!this.app) {
-      return;
-    }
     var path = require('path');
     var fs = require('fs');
     var dotenv = require('dotenv');
-    var app = this.app;
     var project = this.project;
     var loadedConfig;
     var config = {};
     var hasOwn = Object.prototype.hasOwnProperty;
-    if (app.options.dotEnv && hasOwn.call(app.options.dotEnv, 'allow')){
-      console.warn("[EMBER-CLI-DOTENV] app.options.allow has been deprecated. Please use clientAllowedKeys instead. Support will be removed in the next major version");
-    }
-    var allowedKeys = (app.options.dotEnv && (app.options.dotEnv.clientAllowedKeys || app.options.dotEnv.allow) || []);
 
     var configFilePath = path.join(project.root, '.env');
 
@@ -29,6 +21,15 @@ module.exports = {
     } else  {
       loadedConfig = {};
     }
+
+    var app = this.app;
+    if (!this.app) {
+      return;
+    }
+    if (app.options.dotEnv && hasOwn.call(app.options.dotEnv, 'allow')){
+      console.warn("[EMBER-CLI-DOTENV] app.options.allow has been deprecated. Please use clientAllowedKeys instead. Support will be removed in the next major version");
+    }
+    var allowedKeys = (app.options.dotEnv && (app.options.dotEnv.clientAllowedKeys || app.options.dotEnv.allow) || []);
 
     allowedKeys.forEach(function(key){
       config[key] = loadedConfig[key];


### PR DESCRIPTION
This basically allows users to reference `process.env` from within their config/environment file, as stated in the docs.