### PR TITLE
Remove soon-to-be deprecated fs.existsSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
     var path = require('path');
     var fs = require('fs');
     var dotenv = require('dotenv');
+    var existsSync = require('exists-sync');
     var project = this.project;
     var loadedConfig;
     var config = {};
@@ -28,7 +29,7 @@ module.exports = {
       configFilePath = path.join(project.root, '.env');
     }
 
-    if (dotenv.config({path: configFilePath}) && fs.existsSync(configFilePath)) {
+    if (dotenv.config({path: configFilePath}) && existsSync(configFilePath)) {
       loadedConfig = dotenv.parse(fs.readFileSync(configFilePath));
     } else {
       loadedConfig = {};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "dotenv": "^1.0.0"
+    "dotenv": "^1.0.0",
+    "exists-sync": "0.0.3"
   }
 }


### PR DESCRIPTION
It's marked to be deprecated: https://nodejs.org/api/fs.html#fs_fs_exists_path_callback

Bringing over the solution that ember-cli recently merged.