### PR TITLE
add learning resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ module.exports = app.toTree();
 With the above, if you run `ember build --environment production`, the file
 `.env.production` will be used instead.
 
+## Other Resources
+
+* [Emberscreencasts video on using ember-cli-dotenv](https://www.emberscreencasts.com/posts/52-dotenv)
 
 ## Development Installation
 


### PR DESCRIPTION
Hey Stanley!

A while back I made a video about ember-cli-dot-env.  I thought it may be helpful for new users to be able to see how it's used in context.

Of course, you should merge this PR only if the 1.x release doesn't invalidate the old way of using the addon.  But guessing from the fact that the readme hasn't changed, it's probably fine.