### PR TITLE
Avoid errors if .env does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
       configFilePath = path.join(project.root, '.env');
     }
 
-    if (dotenv.config({path: configFilePath}) && existsSync(configFilePath)) {
+    if (existsSync(configFilePath) && dotenv.config({path: configFilePath})) {
       loadedConfig = dotenv.parse(fs.readFileSync(configFilePath));
     } else {
       loadedConfig = {};


### PR DESCRIPTION
Without this change my console is hammered with these messages when the `.env` file does not exist as the config hook seems to be called quite frequently:

```
{ [Error: ENOENT: no such file or directory, open '/some/path/.env']
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/some/path/.env' }
```
