### PR TITLE
Improved test and prod env detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,13 +50,13 @@ module.exports = {
     let args = parseArgs(process.argv);
     let env = args.e || args.env || args.environment;
 
-    // Is it "ember -prod" command?
-    if (!env && process.argv.includes('-prod')) {
+    // Is it "ember b -prod" command?
+    if (!env && process.argv.indexOf('-prod') > -1) {
       env = 'production'
     }
 
-    // Is it "ember test" command without explicit env specified?
-    if (!env && (process.argv.includes('test') || process.argv.includes('t'))) {
+    // Is it "ember test" or "ember t" command without explicit env specified?
+    if (!env && (process.argv.indexOf('test') > -1 || process.argv.indexOf('t') > -1)) {
       env = 'test'
     }
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,16 @@ module.exports = {
     let args = parseArgs(process.argv);
     let env = args.e || args.env || args.environment;
 
+    // Is it "ember -prod" command?
+    if (!env && process.argv.includes('-prod')) {
+      env = 'production'
+    }
+
+    // Is it "ember test" command without explicit env specified?
+    if (!env && (process.argv.includes('test') || process.argv.includes('t'))) {
+      env = 'test'
+    }
+
     return env || 'development';
   },
 

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -121,6 +121,28 @@ describe('with env specific .env path', function() {
 
   });
 
+  describe('for production environment alias command', function() {
+
+    let app;
+
+    before(function() {
+      app = new AddonTestApp();
+
+      return app.create('env-specific-paths')
+        .then(function() {
+          return app.runEmberCommand('build', '-prod');
+        });
+    });
+
+    it('properly resolves environment name', function () {
+      let config = readConfig(app);
+
+      expect(config.DOTENV_VAR).to.equal('production.dotenv');
+      expect(config.IN_PROCESS_ENV).to.equal('PRODUCTION_IN_PROCESS_ENV');
+    });
+
+  });
+
 });
 
 /**


### PR DESCRIPTION
Commands `ember test`, `ember t` and `ember build -prod` do not specify environment name explicitly.
Do our best to identify `test` and `prod` env in `init` hook of the addon.