### PR TITLE
Add FastBoot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ such as express middleware or other servers/tasks.
 **Security: environment variables in `config/environment.js` are never filtered
 unlike using `.env` and `clientAllowedKeys`. Remember to use the `environment`
 variable passed into your config function to filter out secrets for production
-usage.  Never include sensitive variables in `clientAllowedKeys`, as these will
-be exposed publicly via ember's `<meta name="app/config/environment">` tag.**
+usage. Never include sensitive variables in `clientAllowedKeys`, as these will
+be exposed publicly via Ember's `<meta name="app/config/environment">` tag.**
 
-then, you can access the environment variables anywhere in your app like
+Then, you can access the environment variables anywhere in your app like
 you usually would.
 
 ```js
@@ -78,6 +78,31 @@ You can read more about dotenv files on their [dotenv repository][dotenv].
 All the work is done by ember-cli and [dotenv][dotenv]. Thanks ember-cli team and
 dotenv authors and maintainers! Thanks Brandon Keepers for the original dotenv
 ruby implementation.
+
+### FastBoot support
+
+This addon supports FastBoot via `fastbootConfigTree` build hook (requires `ember-cli-fastboot`
+1.1.0 or higher).
+Use `fastbootAllowedKeys` configuration option to make variables available in FastBoot mode
+when Ember application is rendered server-side.
+
+```javascript
+// ember-cli-build.js
+
+module.exports = function(defaults) {
+  let app = new EmberApp(defaults, {
+    dotEnv: {
+      clientAllowedKeys: ['DROPBOX_KEY'],
+      fastbootAllowedKeys: ['MY_API_SECRET', 'MY_OTHER_API_SECRET']
+    }
+  });
+
+  return app.toTree();
+};
+```
+**Note:** keys listed in `fastbootAllowedKeys` are not added to Ember's
+`<meta name="app/config/environment">` tag and are not available to Ember application
+when it's run in browser.
 
 ### Multiple Environments
 
@@ -113,6 +138,8 @@ With the above, if you run `ember build --environment production`, the file
 ## Compatibility
 
 This addon supports the Ember 2.x series, but it is also backwards-compatible down to Ember-CLI 0.1.2 and Ember 1.7.0.
+
+For FastBoot support you need Ember 2.3 or higher (2.12.0 and higher is prefereable by ember-cli-fastboot).
 
 ## Other Resources
 

--- a/config/dotenv.js
+++ b/config/dotenv.js
@@ -3,6 +3,7 @@
 
 module.exports = function() {
   return {
-    clientAllowedKeys: ['DOTENV_VAR']
+    clientAllowedKeys: ['DOTENV_VAR'],
+    fastbootAllowedKeys: ['FASTBOOT_DOTENV_VAR']
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-
 'use strict';
 
 const fs = require('fs');
@@ -28,40 +27,24 @@ module.exports = {
     };
 
     if (fs.existsSync(configFactory)) {
-      Object.assign(options, require(configFactory)(this._resolveEnvironment()));
+      this._config = Object.assign(options, require(configFactory)(this._resolveEnvironment()));
     }
 
-    let loadedConfig = dotenv.config({ path: options.path });
+    let loadedConfig = dotenv.config({path: options.path});
+    this._envConfig = loadedConfig.parsed;
+    this._envConfigError = loadedConfig.error;
+  },
 
+  included() {
     // It might happen that environment config is missing or corrupted
-    if (loadedConfig.error) {
-      let loadingErrMsg = `[ember-cli-dotenv]: ${loadedConfig.error.message}`;
-      if (options.failOnMissingKey) {
+    if (this._envConfigError) {
+      let loadingErrMsg = `[ember-cli-dotenv]: ${this._envConfigError.message}`;
+      if (this._config.failOnMissingKey) {
         throw new Error(loadingErrMsg);
       } else {
-        console.warn(loadingErrMsg);
-        return;
+        this.ui.warn(loadingErrMsg);
       }
     }
-
-    let allowedKeys = options.clientAllowedKeys || [];
-
-    allowedKeys.forEach(key => {
-      if (loadedConfig.parsed[key] === undefined) {
-        let errMsg = '[ember-cli-dotenv]: Required environment variable \'' + key + '\' is missing.';
-        if (options.failOnMissingKey) {
-          throw new Error(errMsg);
-        } else {
-          console.warn(errMsg);
-        }
-      }
-    });
-
-    this._config = allowedKeys.reduce((accumulator, key) => {
-      accumulator[key] = loadedConfig.parsed[key];
-
-      return accumulator;
-    }, {});
   },
 
   _resolveEnvironment() {
@@ -86,6 +69,47 @@ module.exports = {
   },
 
   config() {
-    return this._config;
+    let loadedConfig = this._envConfig || {};
+    let allowedKeys = this._config.clientAllowedKeys || [];
+
+    return allowedKeys.reduce((accumulator, key) => {
+      if (loadedConfig[key] === undefined) {
+        let errMsg = '[ember-cli-dotenv]: Required environment variable \'' + key + '\' is missing.';
+        if (this._config.failOnMissingKey) {
+          throw new Error(errMsg);
+        } else {
+          this.ui.warn(errMsg);
+        }
+      }
+
+      accumulator[key] = loadedConfig[key];
+
+      return accumulator;
+    }, {});
+  },
+
+  fastbootConfigTree() {
+    let loadedConfig = this._envConfig || {};
+    let allowedKeys = this._config.fastbootAllowedKeys || [];
+
+    const config = allowedKeys.reduce((accumulator, key) => {
+      if (loadedConfig[key] === undefined) {
+        let errMsg = '[ember-cli-dotenv]: Required environment variable \'' + key + '\' is missing.';
+        if (this._config.failOnMissingKey) {
+          throw new Error(errMsg);
+        } else {
+          this.ui.warn(errMsg);
+        }
+      }
+
+      accumulator[key] = loadedConfig[key];
+
+      return accumulator;
+    }, {});
+
+    // `fastbootConfigTree` expects key name as app/engine name
+    return {
+      [this.app.name]: config
+    };
   }
 };

--- a/index.js
+++ b/index.js
@@ -88,11 +88,27 @@ module.exports = {
     }, {});
   },
 
+  /**
+   * Reset values listed in `clientAllowedKeys` to null and
+   * add values from `fastbootAllowedKeys` to FastBoot manifest in package.json.
+   *
+   * Users may list in same keys both in `clientAllowedKeys` and
+   * `fastbootAllowedKeys`
+   *
+   * @returns {Object}
+   */
   fastbootConfigTree() {
     let loadedConfig = this._envConfig || {};
-    let allowedKeys = this._config.fastbootAllowedKeys || [];
+    let clientAllowedKeys = this._config.clientAllowedKeys || [];
+    let fastbootAllowedKeys = this._config.fastbootAllowedKeys || [];
 
-    const config = allowedKeys.reduce((accumulator, key) => {
+    let config = clientAllowedKeys.reduce((accumulator, key) => {
+      accumulator[key] = null;
+
+      return accumulator;
+    }, {});
+
+    config = fastbootAllowedKeys.reduce((accumulator, key) => {
       if (loadedConfig[key] === undefined) {
         let errMsg = '[ember-cli-dotenv]: Required environment variable \'' + key + '\' is missing.';
         if (this._config.failOnMissingKey) {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.16.0",
     "ember-welcome-page": "^3.0.0",
+    "fs-extra": "^4.0.2",
     "loader.js": "^4.2.3",
     "mocha": "^4.0.1"
   },

--- a/test/fixtures/custom-path/.env.custom
+++ b/test/fixtures/custom-path/.env.custom
@@ -1,2 +1,3 @@
 DOTENV_VAR="custom.dotenv"
+FASTBOOT_DOTENV_VAR="fastboot dotenv"
 IN_PROCESS_ENV="CUSTOM_IN_PROCESS_ENV"

--- a/test/fixtures/custom-path/config/dotenv.js
+++ b/test/fixtures/custom-path/config/dotenv.js
@@ -4,6 +4,7 @@
 module.exports = function() {
   return {
     clientAllowedKeys: ['DOTENV_VAR'],
+    fastbootAllowedKeys: ['FASTBOOT_DOTENV_VAR'],
     path: './.env.custom'
   }
 };

--- a/test/fixtures/dummy/.env
+++ b/test/fixtures/dummy/.env
@@ -1,2 +1,3 @@
 DOTENV_VAR="dotenv"
+FASTBOOT_DOTENV_VAR="fastboot dotenv"
 IN_PROCESS_ENV="IN_PROCESS_ENV"

--- a/test/fixtures/dummy/config/dotenv.js
+++ b/test/fixtures/dummy/config/dotenv.js
@@ -3,6 +3,7 @@
 
 module.exports = function() {
   return {
-    clientAllowedKeys: ['DOTENV_VAR']
+    clientAllowedKeys: ['DOTENV_VAR'],
+    fastbootAllowedKeys: ['FASTBOOT_DOTENV_VAR']
   }
 };

--- a/test/fixtures/env-specific-paths/.env-development
+++ b/test/fixtures/env-specific-paths/.env-development
@@ -1,2 +1,3 @@
 DOTENV_VAR="development.dotenv"
+FASTBOOT_DOTENV_VAR="development.fastboot dotenv"
 IN_PROCESS_ENV="DEVELOPMENT_IN_PROCESS_ENV"

--- a/test/fixtures/env-specific-paths/.env-production
+++ b/test/fixtures/env-specific-paths/.env-production
@@ -1,2 +1,3 @@
 DOTENV_VAR="production.dotenv"
+FASTBOOT_DOTENV_VAR="production.fastboot dotenv"
 IN_PROCESS_ENV="PRODUCTION_IN_PROCESS_ENV"

--- a/test/fixtures/env-specific-paths/config/dotenv.js
+++ b/test/fixtures/env-specific-paths/config/dotenv.js
@@ -4,6 +4,7 @@
 module.exports = function(env) {
   return {
     clientAllowedKeys: ['DOTENV_VAR'],
+    fastbootAllowedKeys: ['FASTBOOT_DOTENV_VAR'],
     path: `./.env-${env}`
   }
 };

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -166,7 +166,7 @@ describe('generating app build with FastBoot', function() {
       });
   });
 
-  it.only('provides additional config added to package.json', function () {
+  it('provides additional config added to package.json', function () {
     let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
 
     expect(pkg.fastboot.config.dummy.FASTBOOT_DOTENV_VAR).to.equal('fastboot dotenv');

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -4,6 +4,7 @@
 
 const chai         = require('chai');
 const expect       = chai.expect;
+const fs           = require('fs-extra');
 const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 
 describe('with default .env path', function() {
@@ -139,6 +140,43 @@ describe('with env specific .env path', function() {
       expect(config.IN_PROCESS_ENV).to.equal('PRODUCTION_IN_PROCESS_ENV');
     });
 
+  });
+
+});
+
+describe('generating app build with FastBoot', function() {
+  this.timeout(600000);
+
+  let app;
+
+  before(function() {
+    app = new AddonTestApp();
+
+    return app.create('dummy', { skipNpm: true })
+      .then(function(app) {
+        return app.editPackageJSON(pkg => {
+          pkg.devDependencies['ember-cli-fastboot'] = '*';
+        });
+      })
+      .then(function() {
+        return app.run('npm', 'install');
+      })
+      .then(function() {
+        return app.runEmberCommand('build');
+      });
+  });
+
+  it('provides additional config added to package.json', function () {
+    let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
+
+    expect(pkg.fastboot.config.dummy.DOTENV_VAR).to.be.undefined;
+    expect(pkg.fastboot.config.dummy.FASTBOOT_DOTENV_VAR).to.equal('fastboot dotenv');
+  });
+
+  it('fastbootAllowedKeys do not appear in <app name>/config/environment JS module', function () {
+    let config = readConfig(app);
+
+    expect(config.FASTBOOT_DOTENV_VAR).to.be.undefined;
   });
 
 });

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -166,10 +166,9 @@ describe('generating app build with FastBoot', function() {
       });
   });
 
-  it('provides additional config added to package.json', function () {
+  it.only('provides additional config added to package.json', function () {
     let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
 
-    expect(pkg.fastboot.config.dummy.DOTENV_VAR).to.be.undefined;
     expect(pkg.fastboot.config.dummy.FASTBOOT_DOTENV_VAR).to.equal('fastboot dotenv');
   });
 
@@ -177,6 +176,12 @@ describe('generating app build with FastBoot', function() {
     let config = readConfig(app);
 
     expect(config.FASTBOOT_DOTENV_VAR).to.be.undefined;
+  });
+
+  it('clientAllowedKeys do not appear in package.json', function () {
+    let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
+
+    expect(pkg.fastboot.config.dummy.DOTENV_VAR).to.be.undefined;
   });
 
 });


### PR DESCRIPTION
Addresses #24.

Note that `fastbootConfigTree` hook of ember-cli-fastboot has a defect that is not part of 1.1.0, see [ember-cli-fastboot#543](https://github.com/ember-fastboot/ember-cli-fastboot/issues/543)