### PR TITLE
Add ability to shut off dotenv invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ This can be configured as below:
 // config/dotenv.js
 module.exports = function(env) {
   return {
-    useDotenvFile: env !== 'production' // default is TRUE for any environment
+    enabled: env !== 'production' // default is TRUE for any environment
   };
 };
 ```
 
-When `useDotenvFile` is set to `false`, the dotenv protocol will not be used at all.
+When `enabled` is set to `false`, the dotenv protocol will not be used at all.
 This is great for quieting errors and side issues when deploying with a service like Heroku,
  where you can use environment variables set within the service and avoid storing a .env file in your repo.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = function(env) {
     clientAllowedKeys: ['DROPBOX_KEY'],
     // Fail build when there is missing any of clientAllowedKeys environment variables.
     // By default false.
-    failOnMissingKey: false, 
+    failOnMissingKey: false
   };
 };
 ```
@@ -106,7 +106,7 @@ when it runs in browser.
 
 ### Multiple Environments
 
-Sometime people may want to use different `.env` file than the one in project root.
+Sometimes people may want to use different `.env` file than the one in project root.
 This can be configured as below:
 
 ```js
@@ -134,6 +134,24 @@ module.exports = function(env) {
 
 With the above, if you run `ember build --environment production`, the file
 `./path/to/.env-production` will be used instead.
+
+### Environment Specific Use
+
+Sometimes people may want to only initiate the dotenv file in one or more environments (e.g. not in production)
+This can be configured as below:
+
+```js
+// config/dotenv.js
+module.exports = function(env) {
+  return {
+    useDotenvFile: env !== 'production' // default is TRUE for any environment
+  };
+};
+```
+
+When `useDotenvFile` is set to `false`, the dotenv protocol will not be used at all.
+This is great for quieting errors and side issues when deploying with a service like Heroku,
+ where you can use environment variables set within the service and avoid storing a .env file in your repo.
 
 ## Compatibility
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
       clientAllowedKeys: [],
       fastbootAllowedKeys: [],
       failOnMissingKey: false,
-      useDotenvFile: true
+      enabled: true
     };
 
     if (fs.existsSync(configFactory)) {
@@ -33,7 +33,7 @@ module.exports = {
       this._config = options;
     }
 
-    if (this._config.useDotenvFile) {
+    if (this._config.enabled) {
       let loadedConfig = dotenv.config({path: options.path});
       this._envConfig = loadedConfig.parsed;
 
@@ -71,7 +71,7 @@ module.exports = {
   },
 
   config() {
-    if (this._config.useDotenvFile) {
+    if (this._config.enabled) {
       let allowedKeys = this._config.clientAllowedKeys || [];
 
       return this._pickConfigKeys(allowedKeys);

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
       clientAllowedKeys: [],
       fastbootAllowedKeys: [],
       failOnMissingKey: false,
+      useDotenvFile: true
     };
 
     if (fs.existsSync(configFactory)) {
@@ -32,16 +33,18 @@ module.exports = {
       this._config = options;
     }
 
-    let loadedConfig = dotenv.config({path: options.path});
-    this._envConfig = loadedConfig.parsed;
+    if (this._config.useDotenvFile) {
+      let loadedConfig = dotenv.config({path: options.path});
+      this._envConfig = loadedConfig.parsed;
 
-    // It might happen that environment config is missing or corrupted
-    if (loadedConfig.error) {
-      let loadingErrMsg = `[ember-cli-dotenv]: ${loadedConfig.error.message}`;
-      if (options.failOnMissingKey) {
-        throw new Error(loadingErrMsg);
-      } else {
-        console.warn(loadingErrMsg); // eslint-disable-line no-console
+      // It might happen that environment config is missing or corrupted
+      if (loadedConfig.error) {
+        let loadingErrMsg = `[ember-cli-dotenv]: ${loadedConfig.error.message}`;
+        if (options.failOnMissingKey) {
+          throw new Error(loadingErrMsg);
+        } else {
+          console.warn(loadingErrMsg); // eslint-disable-line no-console
+        }
       }
     }
   },
@@ -68,9 +71,13 @@ module.exports = {
   },
 
   config() {
-    let allowedKeys = this._config.clientAllowedKeys || [];
+    if (this._config.useDotenvFile) {
+      let allowedKeys = this._config.clientAllowedKeys || [];
 
-    return this._pickConfigKeys(allowedKeys);
+      return this._pickConfigKeys(allowedKeys);
+    }
+
+    return {};
   },
 
   /**


### PR DESCRIPTION
So, this might be the wrong way to go about doing this, but I've run into two major issues in dealing with this dotenv wrapper for Ember:

1) When deploying to production in Heroku, the warnings can be confusing and alarming, when they really are meaning less because the environment variables are actually set within the Heroku environment; and

2) Sometimes the invocation of dotenv and the errors can cause build errors.

So, I've attempted to add the ability for users to bypass the use of dotenv in certain environments.

It seems there may be some consensus that dotenv should only be used for development (https://stackoverflow.com/questions/52546426/is-module-dotenv-for-development-only), but either way, giving control over the use to developers makes sense.

Happy to re-work, delete, or whatever seems appropriate.

Thanks!