### PR TITLE
Update dotenv to v16 to support the export prefix in env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ember": "ember try:each"
   },
   "dependencies": {
-    "dotenv": "^8.0.0",
+    "dotenv": "^16.0.0",
     "ember-cli-babel": "^7.23.0",
     "minimist": "^1.2.0"
   },
@@ -62,7 +62,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": ">=12"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Support the env vars prefixed with `export`, e.g. `export ENV="dev"` ! 
See https://github.com/fivetanley/ember-cli-dotenv/issues/27
PS:
dotenv now works only on `node>=12`(https://github.com/motdotla/dotenv/blob/master/package.json#L58), means **ember-cli-dotenv** will work only on `node>=12` too(a new release version is required) :)